### PR TITLE
[FIX] - Desk Took Crash (v2.18.0)

### DIFF
--- a/src/note.js
+++ b/src/note.js
@@ -28,7 +28,7 @@ const NoteField = React.forwardRef(({ type }, ref) => {
 
       <Inline space={[2]}>
         {icon && !headline && <CustomIcon style={{ fontSize: 24 }} />}
-        <Text size={[1, 1, 1]} dangerouslySetInnerHTML={{ __html: message }} />
+        <Text size={[1, 1, 1]}>{message}</Text>
       </Inline>
     </Card>
   )


### PR DESCRIPTION
Error: Can only set one of `children` or `props.dangerouslySetInnerHTML`